### PR TITLE
Update pyproject.toml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ grpcio = "^1.54.2"
 protobuf = "^4.23.2"
 click = "^8.1.3"
 hexdump = "^3.3"
+commons = {path = "../commons"}
+zeratool_lib = {path = "../zeratool_lib"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "automatic_exploit_generation"}]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 pwntools = "^4.10.0"
 docker = "^6.1.2"
 grpcio = "^1.54.2"


### PR DESCRIPTION
Using python 3.12 will result into an error because distutils is no longer supported. Downgrading to python 3.10 will solve this issue.